### PR TITLE
اطلاعات ملک اکنون در راهنمای ابزار روی نقشه نمایش داده می‌شود.

### DIFF
--- a/src/client/components/HousesMap.tsx
+++ b/src/client/components/HousesMap.tsx
@@ -123,7 +123,7 @@ export function HousesMap({
     },
     opacity: 0.05,
     stroked: false,
-    pickable: false,
+    pickable: true,
   });
 
   const geoLayer = new GeoJsonLayer({
@@ -152,6 +152,16 @@ export function HousesMap({
       controller={true}
       onViewStateChange={({ viewState: newViewState }) => {
         setViewState(newViewState as MapViewState);
+      }}
+      getTooltip={({ object }: { object?: House }) => {
+        if (!object) {
+          return null;
+        }
+        const price = object.price ? object.price.toLocaleString('fa-IR') : 'نامشخص';
+        const size = typeof object.size === 'number' ? object.size.toLocaleString('fa-IR') : 'نامشخص';
+        return `قیمت: ${price} تومان
+متراژ: ${size} متر مربع
+برای اطلاعات بیشتر کلیک کنید.`;
       }}
       layers={[heatLayer, geoLayer, hoverLayer]}
     >


### PR DESCRIPTION
این تغییرات امکان نمایش اطلاعات ملک (قیمت و مساحت) را هنگام قرار دادن ماوس روی نشانگرهای ملک در نقشه اضافه می‌کند.

جزئیات:
- ویژگی `pickable` برای لایه `ScatterplotLayer` مربوط به نمایش خانه‌ها فعال شد (`true`).
- تابع `getTooltip` به مؤلفه `DeckGL` اضافه شد تا اطلاعات زیر را نمایش دهد:
  - قیمت ملک (با فرمت محلی فارسی)
  - مساحت ملک (با فرمت محلی فارسی)
  - یک پیام راهنما برای کلیک جهت مشاهده جزئیات بیشتر در سایت دیوار.
- با کلیک روی هر نشانگر، همچنان صفحه مربوط به آن ملک در سایت دیوار باز می‌شود.